### PR TITLE
Update index.js to support amounts +999

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -156,7 +156,7 @@ function parseDocuments($) {
       },
       amount: {
         sel: 'td[class="table__body__price"]',
-        parse: val => parseFloat(val.slice(0, -1).replace(',', '.'))
+        parse: val => parseFloat(val.slice(0, -1).replaceAll(' ' ,'').replace(',', '.'))
       },
       type: {
         sel: 'td:nth-child(3)'


### PR DESCRIPTION
Fixing amount not working with values >999

eg.
`<td class="table__body__price">1 107,58€</td>`